### PR TITLE
Only call USP_DM_RefreshInstance on registered paths

### DIFF
--- a/src/vendor/vendor.c
+++ b/src/vendor/vendor.c
@@ -1485,7 +1485,10 @@ int RDK_RefreshInstances(int group_id, char *path, int *expiry_period)
         // If this is an object instance, then refresh it in the data model
         if ((len >= 2) && (name[len-1] == '.') && (IS_NUMERIC(name[len-2])))
         {
-            USP_DM_RefreshInstance(name);
+            if (USP_DM_IsRegistered(name))
+            {
+                USP_DM_RefreshInstance(name);
+            }
         }
         elem = elem->next;
     }


### PR DESCRIPTION
This doesn't seem to be a real issue, but it pollutes the log output with constant errors that can be avoided. This is caused by data model objects that exist on the system but are not in the `usp_dm_params.conf` file. Not all data model objects on the system may be included in the USP Agent config especially when running in a container across multiple products that may have different data model implementations.

OBUSPA will call `RDK_RefreshInstances` with a top-level object like `Device.WiFi.`. Then, this function will get all the data model paths under this object from rbus. It loops through all the objects and calls `USP_DM_RefreshInstance` on them. If a particular object does not exist in the `usp_dm_params.conf` file, then it will log an error. If obuspa is run with `--error` to also log callstacks, then this logs several lines of the callstack as well. This can be avoided by calling `USP_DM_IsRegistered` on the path to see if it was registered from the `usp_dm_params.conf` file and only calling `USP_DM_RefreshInstance` on registered paths.

Log output without this patch:
```
DM_PRIV_GetNodeFromPath: Path is invalid: Device.WiFi.Radio.3.Stats.X_COMCAST-COM_ReceivedSignalLevel.60.
Callstack is:-
 Unknown()
  main()
   MAIN_Start()
    DATA_MODEL_Start()
     DM_INST_VECTOR_RefreshBaselineInstances()
      RefreshBaselineInstances()
       RefreshBaselineInstances()
        RefreshBaselineInstances()
         RefreshInstVector()
          RDK_RefreshInstances()
           DM_INST_VECTOR_RefreshInstance()
            DM_PRIV_GetNodeFromPath()
             USP_ERR_SetMessage()
DM_INST_VECTOR_RefreshInstance: Path (Device.WiFi.Radio.3.Stats.X_COMCAST-COM_ReceivedSignalLevel.60.) does not exist in the schema
Callstack is:-
 Unknown()
  main()
   MAIN_Start()
    DATA_MODEL_Start()
     DM_INST_VECTOR_RefreshBaselineInstances()
      RefreshBaselineInstances()
       RefreshBaselineInstances()
        RefreshBaselineInstances()
         RefreshInstVector()
          RDK_RefreshInstances()
           DM_INST_VECTOR_RefreshInstance()
            USP_ERR_SetMessage()
```